### PR TITLE
Augment Item interface with ISO_3166_1 field

### DIFF
--- a/frontend/src/chakra-ui-autocomplete-item.d.ts
+++ b/frontend/src/chakra-ui-autocomplete-item.d.ts
@@ -1,0 +1,6 @@
+import { Item } from 'chakra-ui-autocomplete';
+declare module 'chakra-ui-autocomplete' {
+  interface Item {
+    ISO_3166_1: string;
+  }
+}


### PR DESCRIPTION
Augments the `Item` interface from `chakra-ui-autocomplete` with a `ISO_3166_1` field